### PR TITLE
Cleanup on user fetch failure

### DIFF
--- a/.changeset/cyan-ravens-wash.md
+++ b/.changeset/cyan-ravens-wash.md
@@ -1,0 +1,5 @@
+---
+'@roll-network/api-client': minor
+---
+
+Allow headers to be overriden

--- a/.changeset/dull-otters-beg.md
+++ b/.changeset/dull-otters-beg.md
@@ -1,0 +1,5 @@
+---
+'@roll-network/auth-sdk': minor
+---
+
+Clean up SDK when user fetch is unsuccessful

--- a/packages/api-client/src/request-manager.ts
+++ b/packages/api-client/src/request-manager.ts
@@ -116,7 +116,7 @@ export default class RequestManager {
     }
 
     if (headers) {
-      options.headers = { ...options.headers, ...headers }
+      options.headers = { ...headers, ...options.headers }
     }
 
     if (this.config.baseUrl && !isAbsoluteUrl(url)) {

--- a/packages/auth-sdk/src/sdk.ts
+++ b/packages/auth-sdk/src/sdk.ts
@@ -47,7 +47,7 @@ class SDK extends EventEmitter {
     }
 
     const newToken = await this.interaction.refreshToken(credentials.token)
-    const user = await this.getUser(newToken)
+    const user = await this.getUser(newToken, userId)
 
     await this.checkTokenResponse(newToken)
 
@@ -70,7 +70,7 @@ class SDK extends EventEmitter {
     }
 
     const newToken = await this.interaction.generateToken(options)
-    const user = await this.getUser(newToken)
+    const user = await this.getUser(newToken, userId)
 
     await this.checkTokenResponse(newToken)
     const newCredentials = {
@@ -90,7 +90,7 @@ class SDK extends EventEmitter {
     if (!token) {
       return
     }
-    const user = await this.getUser(token)
+    const user = await this.getUser(token, userId)
 
     await this.checkTokenResponse(token)
     const credentials: Credentials = {
@@ -177,7 +177,7 @@ class SDK extends EventEmitter {
     }
   }
 
-  private getUser = async (token: Token) => {
+  private getUser = async (token: Token, userId?: string) => {
     try {
       if (this.override?.getUser) {
         return await this.override.getUser(token)
@@ -189,7 +189,7 @@ class SDK extends EventEmitter {
 
       return undefined
     } catch (e) {
-      await this.cleanUp()
+      await this.cleanUp(userId)
     }
   }
 }

--- a/packages/auth-sdk/src/sdk.ts
+++ b/packages/auth-sdk/src/sdk.ts
@@ -178,15 +178,19 @@ class SDK extends EventEmitter {
   }
 
   private getUser = async (token: Token) => {
-    if (this.override?.getUser) {
-      return await this.override.getUser(token)
-    }
+    try {
+      if (this.override?.getUser) {
+        return await this.override.getUser(token)
+      }
 
-    if (this.interaction.getUser) {
-      return await this.interaction.getUser(token)
-    }
+      if (this.interaction.getUser) {
+        return await this.interaction.getUser(token)
+      }
 
-    return undefined
+      return undefined
+    } catch (e) {
+      await this.cleanUp()
+    }
   }
 }
 


### PR DESCRIPTION
## What's done

- Added cleanup on user fetch failure.
- Allowed to override API Client headers.
  - We need when a custom `getUser` function is provided.

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
