### PR TITLE
Bug fix/format the response of Get Platform User balance to return the name of the token instead of Object object

### DIFF
--- a/examples/example-node-api-client/users.ts
+++ b/examples/example-node-api-client/users.ts
@@ -332,7 +332,7 @@ export const getPlatformUserTokenBalance = async () => {
       },
     ])
 
-    const response = await user.getPlatformUserBalance(
+    const response: any = await user.getPlatformUserBalance(
       clientPool.getClient(InteractionType.ClientCredentials).call,
       {
         userType: answers.userType,
@@ -341,7 +341,7 @@ export const getPlatformUserTokenBalance = async () => {
       },
     )
 
-    printTable([response])
+    printTable([{ ...response, token: response.token.symbol }])
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
## What's done
Formatted the way we pass response to `printTable()` in `getPlatformUserBalance().`
 Now when the table is printed, the token column contains the name of the token instead of `Object object`

## How to test

Run `yarn start` in examples/example-node-api, choose **Get Platform User Balance** option in the CLI and pass the credentials.

## Demo (screenshots, recordings, etc.)

<img width="1061" alt="Screenshot 2023-06-28 at 15 02 50" src="https://github.com/roll-network/tryrolljs/assets/98424384/43cf6b5b-7eb6-480a-837d-946ab78efec1">

