### PR TITLE
Bug fix/format the response of Get Platform User balance to return the name of the token instead of Object object 

### DIFF
--- a/examples/example-node-api-client/users.ts
+++ b/examples/example-node-api-client/users.ts
@@ -4,6 +4,12 @@ import inquirer from 'inquirer'
 import { ClientPool } from '@roll-network/api-client'
 import { SDKPool, InteractionType } from '@roll-network/auth-sdk'
 import config, { platformUserConfig } from './config.js'
+interface ResponseType {
+  token: string | TokenSymbolType
+}
+interface TokenSymbolType {
+  symbol: string
+}
 
 export const getUserBalances = async () => {
   try {
@@ -332,7 +338,7 @@ export const getPlatformUserTokenBalance = async () => {
       },
     ])
 
-    const response = await user.getPlatformUserBalance(
+    const response: ResponseType = await user.getPlatformUserBalance(
       clientPool.getClient(InteractionType.ClientCredentials).call,
       {
         userType: answers.userType,
@@ -341,7 +347,21 @@ export const getPlatformUserTokenBalance = async () => {
       },
     )
 
-    printTable([response])
+    let formattedResponse: ResponseType
+
+    if (typeof response.token === 'string') {
+      formattedResponse = {
+        ...response,
+        token: response.token,
+      }
+    } else {
+      formattedResponse = {
+        ...response,
+        token: response.token.symbol,
+      }
+    }
+
+    printTable([formattedResponse])
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
## What's done
- Formatted the way we pass response to `printTable()` in `getPlatformUserBalance().`
- Added ResponseType and TokenSymbolType, as well as a type guard to the formatted response
- Created ResponseType and TokenSymbolType
- Added type guard to check the type of response.token and conditionally access the 'symbol' property. 
Now when the table is printed, the token column contains the name of the token instead of `Object object`

## How to test

Run `yarn start` in examples/example-node-api, choose **Get Platform User Balance** option in the CLI and pass the credentials.

## Demo (screenshots, recordings, etc.)

<img width="1061" alt="Screenshot 2023-06-28 at 15 02 50" src="https://github.com/roll-network/tryrolljs/assets/98424384/43cf6b5b-7eb6-480a-837d-946ab78efec1">

