### PR TITLE
bug: update formatting of the response for Get Platform User balance

### DIFF
--- a/.changeset/olive-toes-remain.md
+++ b/.changeset/olive-toes-remain.md
@@ -1,0 +1,5 @@
+---
+'@roll-network/api': minor
+---
+
+Change response formatting in Get Platform User Balance so that it displays the token symbol correctly

--- a/.changeset/olive-toes-remain.md
+++ b/.changeset/olive-toes-remain.md
@@ -2,4 +2,4 @@
 '@roll-network/api': minor
 ---
 
-Change response formatting in Get Platform User Balance so that it displays the token symbol correctly
+Updated getPlatformUserBalance response type

--- a/examples/example-node-api-client/transaction.ts
+++ b/examples/example-node-api-client/transaction.ts
@@ -98,23 +98,18 @@ export const sendBatchFromPlatformUser = async () => {
 
     let batchSendPrompt = true
 
-    const transactions = []
-
-    const senderAnswers = await inquirer.prompt([
-      {
-        type: 'input',
-        name: 'userType',
-        message: 'User Type (discord, telegram)',
-      },
-      {
-        type: 'input',
-        name: 'platformUserId',
-        message: 'User ID from the external platform',
-      },
-    ])
-
     while (batchSendPrompt) {
       const answers = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'userType',
+          message: 'User Type (discord, telegram)',
+        },
+        {
+          type: 'input',
+          name: 'platformUserId',
+          message: 'User ID from the external platform',
+        },
         {
           type: 'input',
           name: 'toUsername',
@@ -137,57 +132,57 @@ export const sendBatchFromPlatformUser = async () => {
           default: false,
         },
       ])
-      transactions.push({
-        amount: answers.amount,
-        toUsername: answers.toUsername,
-        tokenId: answers.tokenId,
-        note: 'test transaction',
+
+      const userResp = await user.createPlatformUser(
+        clientPool.getClient(InteractionType.ClientCredentials).call,
+        {
+          userType: answers.userType,
+          platformUserId: answers.platformUserId,
+        },
+      )
+
+      const masqueradeToken = await user.getUserMasqueradeToken(
+        clientPool.getClient(InteractionType.ClientCredentials).call,
+        {
+          userId: userResp.userID,
+        },
+      )
+      const clientToken = await sdkPool
+        .getSDK(InteractionType.ClientCredentials)
+        .getToken()
+      if (!clientToken) {
+        throw new Error('Client token is undefined.')
+      }
+
+      await sdkPool.getSDK(InteractionType.MasqueradeToken).generateToken({
+        clientToken: clientToken.access_token,
+        masqueradeToken: masqueradeToken.token,
       })
+
+      const tx = await transaction.send(
+        clientPool.getClient(InteractionType.MasqueradeToken).call,
+
+        {
+          amount: answers.amount,
+          toUsername: answers.toUsername,
+          tokenId: answers.tokenId,
+          note: 'test transaction',
+        },
+      )
+
+      printTable([
+        {
+          from: tx.from.username,
+          to: tx.to.username,
+          token: tx.token.symbol,
+          amount: tx.amount,
+          status: tx.status,
+          type: tx.type,
+        },
+      ])
 
       batchSendPrompt = answers.batchSendAgain
     }
-    const userResp = await user.createPlatformUser(
-      clientPool.getClient(InteractionType.ClientCredentials).call,
-      {
-        userType: senderAnswers.userType,
-        platformUserId: senderAnswers.platformUserId,
-      },
-    )
-
-    const masqueradeToken = await user.getUserMasqueradeToken(
-      clientPool.getClient(InteractionType.ClientCredentials).call,
-      {
-        userId: userResp.userID,
-      },
-    )
-
-    const clientToken = await sdkPool
-      .getSDK(InteractionType.ClientCredentials)
-      .getToken()
-    if (!clientToken) {
-      throw new Error('Client token is undefined.')
-    }
-
-    await sdkPool.getSDK(InteractionType.MasqueradeToken).generateToken({
-      clientToken: clientToken.access_token,
-      masqueradeToken: masqueradeToken.token,
-    })
-    const txs = await transaction.batchSend(
-      clientPool.getClient(InteractionType.MasqueradeToken).call,
-      transactions,
-    )
-    console.log('txs', txs)
-
-    printTable(
-      txs.map((tx) => ({
-        from: tx.from.username,
-        to: tx.to.username,
-        token: tx.token.symbol,
-        amount: tx.amount,
-        status: tx.status,
-        type: tx.type,
-      })),
-    )
   } catch (err) {
     console.error(err)
   }

--- a/examples/example-node-api-client/transaction.ts
+++ b/examples/example-node-api-client/transaction.ts
@@ -98,18 +98,23 @@ export const sendBatchFromPlatformUser = async () => {
 
     let batchSendPrompt = true
 
+    const transactions = []
+
+    const senderAnswers = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'userType',
+        message: 'User Type (discord, telegram)',
+      },
+      {
+        type: 'input',
+        name: 'platformUserId',
+        message: 'User ID from the external platform',
+      },
+    ])
+
     while (batchSendPrompt) {
       const answers = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'userType',
-          message: 'User Type (discord, telegram)',
-        },
-        {
-          type: 'input',
-          name: 'platformUserId',
-          message: 'User ID from the external platform',
-        },
         {
           type: 'input',
           name: 'toUsername',
@@ -132,57 +137,57 @@ export const sendBatchFromPlatformUser = async () => {
           default: false,
         },
       ])
-
-      const userResp = await user.createPlatformUser(
-        clientPool.getClient(InteractionType.ClientCredentials).call,
-        {
-          userType: answers.userType,
-          platformUserId: answers.platformUserId,
-        },
-      )
-
-      const masqueradeToken = await user.getUserMasqueradeToken(
-        clientPool.getClient(InteractionType.ClientCredentials).call,
-        {
-          userId: userResp.userID,
-        },
-      )
-      const clientToken = await sdkPool
-        .getSDK(InteractionType.ClientCredentials)
-        .getToken()
-      if (!clientToken) {
-        throw new Error('Client token is undefined.')
-      }
-
-      await sdkPool.getSDK(InteractionType.MasqueradeToken).generateToken({
-        clientToken: clientToken.access_token,
-        masqueradeToken: masqueradeToken.token,
+      transactions.push({
+        amount: answers.amount,
+        toUsername: answers.toUsername,
+        tokenId: answers.tokenId,
+        note: 'test transaction',
       })
-
-      const tx = await transaction.send(
-        clientPool.getClient(InteractionType.MasqueradeToken).call,
-
-        {
-          amount: answers.amount,
-          toUsername: answers.toUsername,
-          tokenId: answers.tokenId,
-          note: 'test transaction',
-        },
-      )
-
-      printTable([
-        {
-          from: tx.from.username,
-          to: tx.to.username,
-          token: tx.token.symbol,
-          amount: tx.amount,
-          status: tx.status,
-          type: tx.type,
-        },
-      ])
 
       batchSendPrompt = answers.batchSendAgain
     }
+    const userResp = await user.createPlatformUser(
+      clientPool.getClient(InteractionType.ClientCredentials).call,
+      {
+        userType: senderAnswers.userType,
+        platformUserId: senderAnswers.platformUserId,
+      },
+    )
+
+    const masqueradeToken = await user.getUserMasqueradeToken(
+      clientPool.getClient(InteractionType.ClientCredentials).call,
+      {
+        userId: userResp.userID,
+      },
+    )
+
+    const clientToken = await sdkPool
+      .getSDK(InteractionType.ClientCredentials)
+      .getToken()
+    if (!clientToken) {
+      throw new Error('Client token is undefined.')
+    }
+
+    await sdkPool.getSDK(InteractionType.MasqueradeToken).generateToken({
+      clientToken: clientToken.access_token,
+      masqueradeToken: masqueradeToken.token,
+    })
+    const txs = await transaction.batchSend(
+      clientPool.getClient(InteractionType.MasqueradeToken).call,
+      transactions,
+    )
+    console.log('txs', txs)
+
+    printTable(
+      txs.map((tx) => ({
+        from: tx.from.username,
+        to: tx.to.username,
+        token: tx.token.symbol,
+        amount: tx.amount,
+        status: tx.status,
+        type: tx.type,
+      })),
+    )
   } catch (err) {
     console.error(err)
   }

--- a/examples/example-node-api-client/users.ts
+++ b/examples/example-node-api-client/users.ts
@@ -5,6 +5,13 @@ import { ClientPool } from '@roll-network/api-client'
 import { SDKPool, InteractionType } from '@roll-network/auth-sdk'
 import config, { platformUserConfig } from './config.js'
 
+interface ResponseType {
+  token: string | TokenSymbolType
+}
+interface TokenSymbolType {
+  symbol: string
+}
+
 export const getUserBalances = async () => {
   try {
     const sdkPool = new SDKPool(config)
@@ -332,7 +339,7 @@ export const getPlatformUserTokenBalance = async () => {
       },
     ])
 
-    const response = await user.getPlatformUserBalance(
+    const response: ResponseType = await user.getPlatformUserBalance(
       clientPool.getClient(InteractionType.ClientCredentials).call,
       {
         userType: answers.userType,
@@ -341,7 +348,21 @@ export const getPlatformUserTokenBalance = async () => {
       },
     )
 
-    printTable([response])
+    let formattedResponse: ResponseType
+
+    if (typeof response.token === 'string') {
+      formattedResponse = {
+        ...response,
+        token: response.token,
+      }
+    } else {
+      formattedResponse = {
+        ...response,
+        token: response.token.symbol,
+      }
+    }
+
+    printTable([formattedResponse])
   } catch (err) {
     console.error(err)
   }

--- a/examples/example-node-api-client/users.ts
+++ b/examples/example-node-api-client/users.ts
@@ -5,13 +5,6 @@ import { ClientPool } from '@roll-network/api-client'
 import { SDKPool, InteractionType } from '@roll-network/auth-sdk'
 import config, { platformUserConfig } from './config.js'
 
-interface ResponseType {
-  token: string | TokenSymbolType
-}
-interface TokenSymbolType {
-  symbol: string
-}
-
 export const getUserBalances = async () => {
   try {
     const sdkPool = new SDKPool(config)
@@ -339,7 +332,7 @@ export const getPlatformUserTokenBalance = async () => {
       },
     ])
 
-    const response: ResponseType = await user.getPlatformUserBalance(
+    const response = await user.getPlatformUserBalance(
       clientPool.getClient(InteractionType.ClientCredentials).call,
       {
         userType: answers.userType,
@@ -348,21 +341,7 @@ export const getPlatformUserTokenBalance = async () => {
       },
     )
 
-    let formattedResponse: ResponseType
-
-    if (typeof response.token === 'string') {
-      formattedResponse = {
-        ...response,
-        token: response.token,
-      }
-    } else {
-      formattedResponse = {
-        ...response,
-        token: response.token.symbol,
-      }
-    }
-
-    printTable([formattedResponse])
+    printTable([response])
   } catch (err) {
     console.error(err)
   }

--- a/examples/example-node-api-client/users.ts
+++ b/examples/example-node-api-client/users.ts
@@ -340,8 +340,8 @@ export const getPlatformUserTokenBalance = async () => {
         tokenId: answers.tokenId,
       },
     )
-
-    printTable([response])
+    const { token, ...rest } = response
+    printTable([{ tokenSymbol: token.symbol, ...rest }])
   } catch (err) {
     console.error(err)
   }

--- a/packages/api/src/user/types.ts
+++ b/packages/api/src/user/types.ts
@@ -7,6 +7,10 @@ export interface HasBalanceArgs {
   amount: string
 }
 
+export interface TokenSymbolType {
+  symbol: string
+}
+
 export interface GetUserBalancesArgs {
   userId: string
 }

--- a/packages/api/src/user/types.ts
+++ b/packages/api/src/user/types.ts
@@ -7,8 +7,21 @@ export interface HasBalanceArgs {
   amount: string
 }
 
-export interface TokenSymbolType {
+export interface Token {
+  uuid: string
+  name: string
   symbol: string
+  decimals: number
+  logo: string
+  contractAddress: string
+  currentSupply: string
+  totalSupply: string
+}
+
+export interface PlatformUserTokenBalanceResponseData {
+  token: Token
+  amount: string
+  updatedAt: string
 }
 
 export interface GetUserBalancesArgs {

--- a/packages/api/src/user/user.ts
+++ b/packages/api/src/user/user.ts
@@ -13,7 +13,7 @@ import {
   PlatformUserArgs,
   GetUserMasqueradeTokenArgs,
   PlatformUserTokenBalancesArgs,
-  TokenSymbolType,
+  PlatformUserTokenBalanceResponseData,
 } from './types'
 
 export const getMe = (call: Call) => {
@@ -114,15 +114,13 @@ export const getPlatformUserBalance = async (
   call: Call,
   { userType, platformUserId, tokenId }: PlatformUserTokenBalancesArgs,
 ) => {
-  const response = await call<Response<{ token: TokenSymbolType }>>({
+  const response = await call<Response<PlatformUserTokenBalanceResponseData>>({
     url: `/v1/platforms/${userType}/users/${platformUserId}/balances/${tokenId}`,
     method: 'GET',
     authorization: true,
   })
 
-  const token = response.data.token.symbol
-
-  return { ...response.data, token }
+  return response.data
 }
 
 export const getPlatformUserDepositAddress = async (

--- a/packages/api/src/user/user.ts
+++ b/packages/api/src/user/user.ts
@@ -13,6 +13,7 @@ import {
   PlatformUserArgs,
   GetUserMasqueradeTokenArgs,
   PlatformUserTokenBalancesArgs,
+  TokenSymbolType,
 } from './types'
 
 export const getMe = (call: Call) => {
@@ -113,13 +114,15 @@ export const getPlatformUserBalance = async (
   call: Call,
   { userType, platformUserId, tokenId }: PlatformUserTokenBalancesArgs,
 ) => {
-  const response = await call<Response<{ token: string }>>({
+  const response = await call<Response<{ token: TokenSymbolType }>>({
     url: `/v1/platforms/${userType}/users/${platformUserId}/balances/${tokenId}`,
     method: 'GET',
     authorization: true,
   })
 
-  return response.data
+  const token = response.data.token.symbol
+
+  return { ...response.data, token }
 }
 
 export const getPlatformUserDepositAddress = async (


### PR DESCRIPTION
## What's done
- Formatted the way we pass response to `printTable()` in `getPlatformUserBalance().`
- Added ResponseType and TokenSymbolType, as well as a type guard to the formatted response
- Created ResponseType and TokenSymbolType
- Added type guard to check the type of response.token and conditionally access the 'symbol' property. 
Now when the table is printed, the token column contains the name of the token instead of `Object object`

## How to test

Run `yarn start` in examples/example-node-api, choose **Get Platform User Balance** option in the CLI and pass the credentials.

## Demo (screenshots, recordings, etc.)

<img width="1061" alt="Screenshot 2023-06-28 at 15 02 50" src="https://github.com/roll-network/tryrolljs/assets/98424384/43cf6b5b-7eb6-480a-837d-946ab78efec1">
