### PR TITLE
fix: refactor batchSend function and implementation of sendBatchFromPlatformUser

### DIFF
--- a/examples/example-node-api-client/transaction.ts
+++ b/examples/example-node-api-client/transaction.ts
@@ -98,18 +98,23 @@ export const sendBatchFromPlatformUser = async () => {
 
     let batchSendPrompt = true
 
+    const transactions = []
+
+    const senderAnswers = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'userType',
+        message: 'User Type (discord, telegram)',
+      },
+      {
+        type: 'input',
+        name: 'platformUserId',
+        message: 'User ID from the external platform',
+      },
+    ])
+
     while (batchSendPrompt) {
       const answers = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'userType',
-          message: 'User Type (discord, telegram)',
-        },
-        {
-          type: 'input',
-          name: 'platformUserId',
-          message: 'User ID from the external platform',
-        },
         {
           type: 'input',
           name: 'toUsername',
@@ -132,57 +137,59 @@ export const sendBatchFromPlatformUser = async () => {
           default: false,
         },
       ])
+      console.log('answers:', answers)
 
-      const userResp = await user.createPlatformUser(
-        clientPool.getClient(InteractionType.ClientCredentials).call,
-        {
-          userType: answers.userType,
-          platformUserId: answers.platformUserId,
-        },
-      )
-
-      const masqueradeToken = await user.getUserMasqueradeToken(
-        clientPool.getClient(InteractionType.ClientCredentials).call,
-        {
-          userId: userResp.userID,
-        },
-      )
-      const clientToken = await sdkPool
-        .getSDK(InteractionType.ClientCredentials)
-        .getToken()
-      if (!clientToken) {
-        throw new Error('Client token is undefined.')
-      }
-
-      await sdkPool.getSDK(InteractionType.MasqueradeToken).generateToken({
-        clientToken: clientToken.access_token,
-        masqueradeToken: masqueradeToken.token,
+      transactions.push({
+        amount: answers.amount,
+        toUsername: answers.toUsername,
+        tokenId: answers.tokenId,
+        note: 'test transaction',
       })
-
-      const tx = await transaction.send(
-        clientPool.getClient(InteractionType.MasqueradeToken).call,
-
-        {
-          amount: answers.amount,
-          toUsername: answers.toUsername,
-          tokenId: answers.tokenId,
-          note: 'test transaction',
-        },
-      )
-
-      printTable([
-        {
-          from: tx.from.username,
-          to: tx.to.username,
-          token: tx.token.symbol,
-          amount: tx.amount,
-          status: tx.status,
-          type: tx.type,
-        },
-      ])
 
       batchSendPrompt = answers.batchSendAgain
     }
+    const userResp = await user.createPlatformUser(
+      clientPool.getClient(InteractionType.ClientCredentials).call,
+      {
+        userType: senderAnswers.userType,
+        platformUserId: senderAnswers.platformUserId,
+      },
+    )
+
+    const masqueradeToken = await user.getUserMasqueradeToken(
+      clientPool.getClient(InteractionType.ClientCredentials).call,
+      {
+        userId: userResp.userID,
+      },
+    )
+
+    const clientToken = await sdkPool
+      .getSDK(InteractionType.ClientCredentials)
+      .getToken()
+    if (!clientToken) {
+      throw new Error('Client token is undefined.')
+    }
+
+    await sdkPool.getSDK(InteractionType.MasqueradeToken).generateToken({
+      clientToken: clientToken.access_token,
+      masqueradeToken: masqueradeToken.token,
+    })
+    const txs = await transaction.batchSend(
+      clientPool.getClient(InteractionType.MasqueradeToken).call,
+      transactions,
+    )
+    console.log('tsx', txs)
+
+    printTable(
+      txs.map((tx) => ({
+        from: tx.from.username,
+        to: tx.to.username,
+        token: tx.token.symbol,
+        amount: tx.amount,
+        status: tx.status,
+        type: tx.type,
+      })),
+    )
   } catch (err) {
     console.error(err)
   }

--- a/examples/example-node-api-client/transaction.ts
+++ b/examples/example-node-api-client/transaction.ts
@@ -99,6 +99,7 @@ export const sendBatchFromPlatformUser = async () => {
     let batchSendPrompt = true
 
     const transactions = []
+    const transactionResponses = []
 
     const senderAnswers = await inquirer.prompt([
       {
@@ -178,18 +179,17 @@ export const sendBatchFromPlatformUser = async () => {
       clientPool.getClient(InteractionType.MasqueradeToken).call,
       transactions,
     )
-    console.log('tsx', txs)
+
+    transactionResponses.push(txs)
 
     printTable(
-      txs.map((tx) => ({
-        from: tx.from.username,
-        to: tx.to.username,
-        token: tx.token.symbol,
-        amount: tx.amount,
-        status: tx.status,
-        type: tx.type,
+      transactionResponses.map((tx) => ({
+        uuid: tx.uuid,
+        totalTxnCount: tx.totalTxnCount,
       })),
     )
+
+    printTable([txs])
   } catch (err) {
     console.error(err)
   }

--- a/packages/api/src/transaction/transaction.ts
+++ b/packages/api/src/transaction/transaction.ts
@@ -4,6 +4,7 @@ import {
   TransactionResponseData,
   GetTransactionByIdArgs,
   Response,
+  BatchSendResponseData,
 } from './types'
 
 export const send = async (
@@ -44,19 +45,14 @@ export const batchSend = async (call: Call, transactions: Array<SendArgs>) => {
       ...transaction,
       tokenID: tokenId,
     }))
-    console.log('body:', body)
-    const response = await call<Response<Array<TransactionResponseData>>>({
+    const response = await call<BatchSendResponseData>({
       url: '/v1/transactions/batch',
       method: 'POST',
       authorization: true,
       body,
     })
 
-    console.log('response:', response)
-
-    console.log('response.data:', response.data)
-
-    return response.data
+    return response
   } catch (err) {
     console.error(err)
     throw err

--- a/packages/api/src/transaction/transaction.ts
+++ b/packages/api/src/transaction/transaction.ts
@@ -44,13 +44,17 @@ export const batchSend = async (call: Call, transactions: Array<SendArgs>) => {
       ...transaction,
       tokenID: tokenId,
     }))
-
+    console.log('body:', body)
     const response = await call<Response<Array<TransactionResponseData>>>({
       url: '/v1/transactions/batch',
       method: 'POST',
       authorization: true,
       body,
     })
+
+    console.log('response:', response)
+
+    console.log('response.data:', response.data)
 
     return response.data
   } catch (err) {

--- a/packages/api/src/transaction/types.ts
+++ b/packages/api/src/transaction/types.ts
@@ -46,3 +46,8 @@ export interface TransactionResponseData {
   type: string
   createdAt: string
 }
+
+export interface BatchSendResponseData {
+  uuid: string
+  totalTxnCount: number
+}


### PR DESCRIPTION
## What's done
- Change the response of batchSend from response.data to response
- Utilise batchSend in sendBatchFromPlatformUser
- Refactor the sendBatchFromPlatformUser so that it stores transaction responses and prints them in the table
- Add a new interface BatchSendResponseData 
- Type the response of batchSend with BatchSendResponseData interface

## How to test

Choose Send Batch From Platform User in the CLI tool and input your credentials.

## Tasks

  - [ x] CLI

## Demo (screenshots, recordings, etc.)

<img width="849" alt="Screenshot 2023-06-29 at 16 54 45" src="https://github.com/roll-network/tryrolljs/assets/98424384/e5db8271-6e19-4fae-8565-135e3d75dfa5">
