### PR TITLE
fix: error response on client-api

### DIFF
--- a/.changeset/pink-coats-admire.md
+++ b/.changeset/pink-coats-admire.md
@@ -1,0 +1,5 @@
+---
+'@roll-network/api-client': minor
+---
+
+Fixed error response

--- a/packages/api-client/src/request-manager.ts
+++ b/packages/api-client/src/request-manager.ts
@@ -172,7 +172,7 @@ export default class RequestManager {
 
   private parseResponseError = (response: AxiosResponse) => {
     if (typeof response.data === 'object') {
-      const error = response.data?.errors?.[0] ?? response.data
+      const error = response.data?.errors ?? response.data
       return {
         message: error.message ?? '',
         details: error.details ?? '',


### PR DESCRIPTION
## What's done
There was an error on parsing the error response from backend.

## Issue
https://github.com/roll-network/roll-go/issues/3801
## How to test
- Run example-node-api-client 
- Try any option and forced an error on it
- A formatted error response should show up.
## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
<img width="445" alt="Screenshot 2023-07-11 at 9 19 34 AM" src="https://github.com/roll-network/tryrolljs/assets/106546965/46b8dbb8-aa3a-410b-8922-4a27b060a486">
