### PR TITLE
Fixed Table search is not shown when no filter

### DIFF
--- a/.changeset/itchy-gorillas-dress.md
+++ b/.changeset/itchy-gorillas-dress.md
@@ -1,0 +1,5 @@
+---
+'@roll-network/design-system': patch
+---
+
+Fixed Table search is not shown when no filter

--- a/packages/design-system/src/organisms/table/table.native.tsx
+++ b/packages/design-system/src/organisms/table/table.native.tsx
@@ -80,7 +80,7 @@ const Table = <T extends any, F extends string>({
         style,
       ]}
     >
-      {filter && (
+      {(filter || search) && (
         <View style={margin.mb12}>
           <View style={margin.mb12}>
             {search && (

--- a/packages/design-system/src/organisms/table/table.web.tsx
+++ b/packages/design-system/src/organisms/table/table.web.tsx
@@ -86,7 +86,7 @@ const Table = <T extends any, F extends string>({
         style,
       ]}
     >
-      {filter && (
+      {(filter || search) && (
         <View
           style={[
             container.row,


### PR DESCRIPTION
## What's done

Fixed Table search is not shown when no filter

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
