### PR TITLE
Allow TypographyV2 to render nested texts

### DIFF
--- a/.changeset/hip-walls-confess.md
+++ b/.changeset/hip-walls-confess.md
@@ -1,0 +1,5 @@
+---
+'@roll-network/design-system': minor
+---
+
+Allow TypogrpahyV2 to render nested texts

--- a/packages/design-system/src/atoms/typographyV2/index.tsx
+++ b/packages/design-system/src/atoms/typographyV2/index.tsx
@@ -1,5 +1,6 @@
 import { useBreakpointValue } from 'native-base'
 import { GestureResponderEvent, StyleProp, Text, TextStyle } from 'react-native'
+import { ReactNode } from 'react'
 import { fontStyles, responsiveFontStyles } from '../../styles'
 
 export type TypographyVariant =
@@ -28,7 +29,7 @@ export interface TypographyV2Props {
   onPress?: (event: GestureResponderEvent) => void
   selectable?: boolean
   testID?: string
-  children?: string | string[]
+  children?: string | string[] | ReactNode | ReactNode[]
 }
 
 export const TypographyV2 = ({
@@ -46,6 +47,7 @@ export const TypographyV2 = ({
     base: responsiveFontStyles,
     xl: fontStyles,
   })
+
   return (
     <Text
       numberOfLines={numberOfLines}

--- a/packages/design-system/src/atoms/typographyV2/typographyV2.stories.tsx
+++ b/packages/design-system/src/atoms/typographyV2/typographyV2.stories.tsx
@@ -1,3 +1,5 @@
+import { action } from '@storybook/addon-actions'
+import { Pressable } from 'react-native'
 import { titleBuilder, fromTemplate } from '../../../.storybook/utils'
 import { TypographyV2, TypographyV2Props } from '.'
 
@@ -6,8 +8,10 @@ const storyConfig = {
   component: TypographyV2,
 }
 
+const DEFAULT_CHILDREN = 'Hello world'
+
 const Template = (props: TypographyV2Props) => (
-  <TypographyV2 {...props}>Hello world</TypographyV2>
+  <TypographyV2 {...props}>{props.children ?? DEFAULT_CHILDREN}</TypographyV2>
 )
 
 export const Caption2 = fromTemplate(Template, {
@@ -45,6 +49,19 @@ export const H2 = fromTemplate(Template, {
 })
 export const H1 = fromTemplate(Template, {
   variant: 'h1',
+})
+export const NestedText = fromTemplate(Template, {
+  variant: 'text2',
+  children: (
+    <>
+      TypographyV2 can render nested texts inside like{' '}
+      <TypographyV2 variant="caption1">Caption1</TypographyV2> or{' '}
+      <Pressable onPress={action('onPress')}>
+        <TypographyV2 variant="caption1">Pressable Caption1</TypographyV2>
+      </Pressable>
+      . But be aware, that nested texts should be of Text or TypographyV2 types.
+    </>
+  ),
 })
 
 export default storyConfig

--- a/packages/design-system/src/molecules/select/index.tsx
+++ b/packages/design-system/src/molecules/select/index.tsx
@@ -19,7 +19,11 @@ export interface SelectProps {
   onChange?: (value: string) => void
 }
 
-const styles = makeStyles({ input: { cursor: 'pointer' } as any })
+const styles = makeStyles({
+  input: {
+    cursor: Platform.select({ web: 'pointer', native: undefined }),
+  } as any,
+})
 
 export const Select = ({
   style,

--- a/packages/design-system/src/molecules/selectV2/index.tsx
+++ b/packages/design-system/src/molecules/selectV2/index.tsx
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   input: {
-    cursor: 'pointer',
+    cursor: Platform.select({ web: 'pointer', native: undefined }),
   } as any,
 })
 


### PR DESCRIPTION
## What's done

- Allowed TypographyV2 to render nested texts.
- Fixed an issue with cursor: pointer style being passed to native components.

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)

<img width="561" alt="Screenshot 2023-08-04 at 11 14 01" src="https://github.com/roll-network/tryrolljs/assets/17337276/eab1ef13-e0a1-46fa-b3cf-7717a61168be">
<img width="1510" alt="Screenshot 2023-08-04 at 11 15 58" src="https://github.com/roll-network/tryrolljs/assets/17337276/e88e90f9-7d3c-4d11-9da6-7b67d6859514">

